### PR TITLE
add bpm effect

### DIFF
--- a/scenes/prefabs/Player/BPMEffect.gd
+++ b/scenes/prefabs/Player/BPMEffect.gd
@@ -1,0 +1,12 @@
+extends AnimatedSprite
+
+onready var timer = $Timer
+onready var neon_effect = preload("res://scenes/prefabs/Player/NeonEffect.tscn")
+
+func _on_Timer_timeout():
+	var neon_effect_instance = neon_effect.instance()
+	neon_effect_instance.position = get_global_position()
+	neon_effect_instance.animation = animation
+	neon_effect_instance.frame = frame
+	neon_effect_instance.flip_h = flip_h
+	get_tree().root.add_child(neon_effect_instance)

--- a/scenes/prefabs/Player/NeonEffect.gd
+++ b/scenes/prefabs/Player/NeonEffect.gd
@@ -1,0 +1,11 @@
+extends AnimatedSprite
+
+func _ready():
+	var tween = $Tween
+	tween.interpolate_property(self, "modulate:a",
+	1, 0, 1,
+	Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+	tween.start()
+
+func _on_Tween_tween_all_completed():
+	queue_free()

--- a/scenes/prefabs/Player/NeonEffect.tscn
+++ b/scenes/prefabs/Player/NeonEffect.tscn
@@ -1,11 +1,21 @@
 [gd_scene load_steps=30 format=2]
 
 [ext_resource path="res://res/textures/sprites/moose4.png" type="Texture" id=1]
-[ext_resource path="res://scenes/prefabs/Player/Player.gd" type="Script" id=2]
-[ext_resource path="res://scenes/prefabs/Player/BPMEffect.gd" type="Script" id=3]
+[ext_resource path="res://scenes/prefabs/Player/NeonEffect.gd" type="Script" id=2]
 
-[sub_resource type="RectangleShape2D" id=26]
-extents = Vector2( 4.5, 13.5 )
+[sub_resource type="Shader" id=25]
+code = "shader_type canvas_item;
+
+uniform vec4 neon_color : hint_color;
+
+void fragment() {
+	vec4 texture_color = texture(TEXTURE, UV);
+	COLOR = vec4(neon_color.rgb, texture_color.a);
+}"
+
+[sub_resource type="ShaderMaterial" id=26]
+shader = SubResource( 25 )
+shader_param/neon_color = Color( 0.411765, 0.109804, 0.662745, 1 )
 
 [sub_resource type="AtlasTexture" id=1]
 atlas = ExtResource( 1 )
@@ -103,7 +113,7 @@ region = Rect2( 168, 56, 28, 28 )
 atlas = ExtResource( 1 )
 region = Rect2( 196, 56, 28, 28 )
 
-[sub_resource type="SpriteFrames" id=25]
+[sub_resource type="SpriteFrames" id=27]
 animations = [ {
 "frames": [ SubResource( 1 ), SubResource( 2 ), SubResource( 3 ), SubResource( 4 ), SubResource( 5 ), SubResource( 6 ), SubResource( 7 ), SubResource( 8 ) ],
 "loop": true,
@@ -121,26 +131,13 @@ animations = [ {
 "speed": 8.0
 } ]
 
-[node name="tmpPlayer" type="KinematicBody2D" groups=["Player"]]
+[node name="AnimatedSprite" type="AnimatedSprite"]
+material = SubResource( 26 )
+position = Vector2( 0, -14 )
+frames = SubResource( 27 )
+animation = "idle"
 script = ExtResource( 2 )
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 0.5, -13.5 )
-shape = SubResource( 26 )
+[node name="Tween" type="Tween" parent="."]
 
-[node name="AnimatedSprite" type="AnimatedSprite" parent="."]
-position = Vector2( 0, -14 )
-frames = SubResource( 25 )
-animation = "idle"
-script = ExtResource( 3 )
-
-[node name="Timer" type="Timer" parent="AnimatedSprite"]
-wait_time = 0.4
-
-[node name="Camera2D" type="Camera2D" parent="."]
-offset = Vector2( 0, -14 )
-current = true
-zoom = Vector2( 0.25, 0.25 )
-smoothing_enabled = true
-
-[connection signal="timeout" from="AnimatedSprite/Timer" to="AnimatedSprite" method="_on_Timer_timeout"]
+[connection signal="tween_all_completed" from="Tween" to="." method="_on_Tween_tween_all_completed"]

--- a/scenes/prefabs/Player/Player.gd
+++ b/scenes/prefabs/Player/Player.gd
@@ -61,6 +61,9 @@ func Interact(delta):
 func _ready():
 	$AnimatedSprite.flip_h = face_left_on_start
 	GameManager.connect("hotspot_interaction", self, "_on_Hotspot_interaction")
+	print(GameManager.current_scene)
+	if GameManager.current_scene == "res/scenes/Infinihallway/Infinihallway.tmx":
+		start_bpm_effect()
 
 func _process(delta):
 	if GameManager.game_state != GameManager.GameState.IMV:
@@ -136,3 +139,6 @@ func _on_Hotspot_interaction(hotspot):
 	current_hotspot = hotspot
 	destination = hotspot.global_position + Vector2(hotspot.width/2, hotspot.height/2)
 	SetState(State.WALKING)
+
+func start_bpm_effect():
+	$AnimatedSprite/Timer.start()


### PR DESCRIPTION
The effect is created using a scene that fades out a "neon" version of a frame of the player's AnimatedSprite at a certain frequency determined by a timer.
The neon AnimatedSprite is rendered using a shader.

The effect is only active on the infinihallway scene, so automatically activating the effect for this situation was hard-coded in the player. Though the effect could still be activated through calling a function that does just that.