### PR TITLE
add fading to items' icon and name

### DIFF
--- a/godot-project/greyscale.gdshader
+++ b/godot-project/greyscale.gdshader
@@ -2,11 +2,18 @@ shader_type canvas_item;
 render_mode unshaded;
 
 uniform bool enable = true;
+uniform float time_when_changed = 1.0f;
 
 void fragment() {
+	float change_delta_time = TIME - time_when_changed;
+	float clamp_change_delta_time = clamp(change_delta_time*9.0, 0, 1);
 	COLOR = texture(TEXTURE, UV);
+	float lumi = COLOR.r * 0.2126 + COLOR.g * 0.7152 + COLOR.b * 0.0722;
+	
 	if (enable) {
-		float lumi = COLOR.r * 0.2126 + COLOR.g * 0.7152 + COLOR.b * 0.0722;
-		COLOR.rgb = vec3(lumi);
+		COLOR.rgb = mix(COLOR.rgb, vec3(lumi), clamp_change_delta_time);
+	}
+	else {
+		COLOR.rgb = mix(vec3(lumi), COLOR.rgb, clamp_change_delta_time);
 	}
 }

--- a/godot-project/greyscale.gdshader
+++ b/godot-project/greyscale.gdshader
@@ -5,7 +5,7 @@ uniform bool enable = true;
 uniform float time_when_changed = 1.0f;
 
 void fragment() {
-	float change_delta_time = TIME - time_when_changed;
+	float change_delta_time = TIME - time_when_changed+0.25;
 	float clamp_change_delta_time = clamp(change_delta_time*9.0, 0, 1);
 	COLOR = texture(TEXTURE, UV);
 	float lumi = COLOR.r * 0.2126 + COLOR.g * 0.7152 + COLOR.b * 0.0722;

--- a/godot-project/item_text.gdshader
+++ b/godot-project/item_text.gdshader
@@ -5,7 +5,7 @@ uniform bool enable = true;
 uniform float time_when_changed = 1.0f;
 
 void fragment() {
-	float change_delta_time = TIME - time_when_changed;
+	float change_delta_time = TIME - time_when_changed+0.25;
 	float clamp_change_delta_time = clamp(change_delta_time*9.0, 0, 1);
 	COLOR = texture(TEXTURE, UV);
 	

--- a/godot-project/item_text.gdshader
+++ b/godot-project/item_text.gdshader
@@ -1,0 +1,18 @@
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform bool enable = true;
+uniform float time_when_changed = 1.0f;
+
+void fragment() {
+	float change_delta_time = TIME - time_when_changed;
+	float clamp_change_delta_time = clamp(change_delta_time*9.0, 0, 1);
+	COLOR = texture(TEXTURE, UV);
+	
+	if (enable) {
+		COLOR.a = mix(COLOR.a, 0.0, clamp_change_delta_time);
+	}
+	else {
+		COLOR.a = mix(0.0, COLOR.a, clamp_change_delta_time);
+	}
+}

--- a/godot-project/scenes/prefabs/Inventory/Inventory.gd
+++ b/godot-project/scenes/prefabs/Inventory/Inventory.gd
@@ -31,6 +31,7 @@ func show_item_info(i):
 			item_icon_node_path = "AspectRatioContainer/MarginContainer/HBoxContainer/HBoxContainerRight/ItemContainer" + str(i) + "/ItemSlot/ItemIcon"
 		var item_icon_node = get_node(item_icon_node_path)
 		item_icon_node.get_material().set_shader_param("enable", false)
+		item_icon_node.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
 	label_item_name.text = item_name
 
 func hide_item_info(i):
@@ -43,6 +44,7 @@ func hide_item_info(i):
 			item_icon_node_path = "AspectRatioContainer/MarginContainer/HBoxContainer/HBoxContainerRight/ItemContainer" + str(i) + "/ItemSlot/ItemIcon"
 		var item_icon_node = get_node(item_icon_node_path)
 		item_icon_node.get_material().set_shader_param("enable", true)
+		item_icon_node.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
 
 func _on_ItemIcon_mouse_entered0():
 	show_item_info(0)

--- a/godot-project/scenes/prefabs/Inventory/Inventory.gd
+++ b/godot-project/scenes/prefabs/Inventory/Inventory.gd
@@ -33,9 +33,10 @@ func show_item_info(i):
 		item_icon_node.get_material().set_shader_param("enable", false)
 		item_icon_node.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
 	label_item_name.text = item_name
+	label_item_name.get_material().set_shader_param("enable", false)
+	label_item_name.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
 
 func hide_item_info(i):
-	label_item_name.text = ""
 	if GameManager.items[i] != null:
 		var item_icon_node_path = ""
 		if i < 5:
@@ -45,6 +46,8 @@ func hide_item_info(i):
 		var item_icon_node = get_node(item_icon_node_path)
 		item_icon_node.get_material().set_shader_param("enable", true)
 		item_icon_node.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
+	label_item_name.get_material().set_shader_param("enable", true)
+	label_item_name.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
 
 func _on_ItemIcon_mouse_entered0():
 	show_item_info(0)

--- a/godot-project/scenes/prefabs/Inventory/Inventory.gd
+++ b/godot-project/scenes/prefabs/Inventory/Inventory.gd
@@ -32,9 +32,10 @@ func show_item_info(i):
 		var item_icon_node = get_node(item_icon_node_path)
 		item_icon_node.get_material().set_shader_param("enable", false)
 		item_icon_node.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
-	label_item_name.text = item_name
-	label_item_name.get_material().set_shader_param("enable", false)
-	label_item_name.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
+	if item_name != "":
+		label_item_name.text = item_name
+		label_item_name.get_material().set_shader_param("enable", false)
+		label_item_name.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
 
 func hide_item_info(i):
 	if GameManager.items[i] != null:
@@ -46,8 +47,9 @@ func hide_item_info(i):
 		var item_icon_node = get_node(item_icon_node_path)
 		item_icon_node.get_material().set_shader_param("enable", true)
 		item_icon_node.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
-	label_item_name.get_material().set_shader_param("enable", true)
-	label_item_name.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
+	if GameManager.items[i] != null:
+		label_item_name.get_material().set_shader_param("enable", true)
+		label_item_name.get_material().set_shader_param("time_when_changed", OS.get_ticks_msec()/1000.0)
 
 func _on_ItemIcon_mouse_entered0():
 	show_item_info(0)

--- a/godot-project/scenes/prefabs/Inventory/Inventory.tscn
+++ b/godot-project/scenes/prefabs/Inventory/Inventory.tscn
@@ -1,10 +1,16 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://res/textures/sprites/inventory/inventory.png" type="Texture" id=1]
 [ext_resource path="res://res/textures/sprites/inventory/item_slot.png" type="Texture" id=2]
 [ext_resource path="res://scenes/prefabs/Inventory/Inventory.gd" type="Script" id=3]
 [ext_resource path="res://res/fonts/VCR OSD Mono.ttf" type="DynamicFontData" id=4]
 [ext_resource path="res://greyscale.gdshader" type="Shader" id=5]
+[ext_resource path="res://item_text.gdshader" type="Shader" id=6]
+
+[sub_resource type="ShaderMaterial" id=13]
+shader = ExtResource( 6 )
+shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="DynamicFont" id=1]
 font_data = ExtResource( 4 )
@@ -15,47 +21,58 @@ default_font = SubResource( 1 )
 [sub_resource type="ShaderMaterial" id=3]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=4]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=5]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=6]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=7]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=8]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=9]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=10]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=11]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [sub_resource type="ShaderMaterial" id=12]
 shader = ExtResource( 5 )
 shader_param/enable = true
+shader_param/time_when_changed = 1.0
 
 [node name="Inventory" type="CanvasLayer"]
 script = ExtResource( 3 )
 
 [node name="LabelItemName" type="Label" parent="."]
+material = SubResource( 13 )
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5


### PR DESCRIPTION
When hovering items:

- Items' icon fades in and out from grey scale to colour.
- Items' name's alpha fades in and out.